### PR TITLE
refactor: separate storage layer and reed-solomon helpers

### DIFF
--- a/debug_test.go
+++ b/debug_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dgraph-io/badger/v4"
 	crypt "github.com/i5heu/ouroboros-crypt"
 	"github.com/i5heu/ouroboros-crypt/hash"
+	"github.com/i5heu/ouroboros-kv/storage"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -78,7 +79,7 @@ func TestDebugParentChildStorage(t *testing.T) {
 	fmt.Printf("Looking for children of parent: %s\n", parentData.Key)
 
 	// Create the exact prefix we'll be searching for
-	searchPrefix := fmt.Sprintf("%s%s:", PARENT_PREFIX, parentData.Key)
+	searchPrefix := fmt.Sprintf("%s%s:", storage.ParentPrefix, parentData.Key)
 	fmt.Printf("Search prefix: %s\n", searchPrefix) // Check if any keys match this prefix
 	kv.badgerDB.View(func(txn *badger.Txn) error {
 		prefix := []byte(searchPrefix)
@@ -105,7 +106,7 @@ func TestDebugParentChildStorage(t *testing.T) {
 
 	// Let me manually test the parsing logic
 	testKey := "parent:ca554068e9109c5fbb193bdaeec5bcbcfe2754528f3cf52a4078f00f76138b3071dc37aa16b7c727fce21f56b5252c1cf41c26f3605879004aeff5af75e00ce0:bc0a7a7acbebda6b21f2eef5ff2a4f5f1629bd0212e5db0f654555874c00e13421c494db2fdab1abc192b665d851acae71e80d7f4971fe7c83be3a3115786708"
-	prefix := fmt.Sprintf("%s%s:", PARENT_PREFIX, parentData.Key)
+	prefix := fmt.Sprintf("%s%s:", storage.ParentPrefix, parentData.Key)
 	fmt.Printf("Prefix: '%s'\n", prefix)
 	fmt.Printf("Test key: '%s'\n", testKey)
 	fmt.Printf("Prefix length: %d\n", len(prefix))

--- a/encryptionPipeline.go
+++ b/encryptionPipeline.go
@@ -1,20 +1,14 @@
 package ouroboroskv
 
 import (
-	"bytes"
-	"fmt"
-	"io"
-
 	"github.com/i5heu/ouroboros-crypt/encrypt"
 	"github.com/i5heu/ouroboros-crypt/hash"
-	chunker "github.com/ipfs/boxo/chunker"
-	"github.com/klauspost/compress/zstd"
-	"github.com/klauspost/reedsolomon"
+	"github.com/i5heu/ouroboros-kv/pipeline"
 )
 
 func (k *KV) encodeDataPipeline(data Data) (kvDataLinked, error) {
 	// chunk the data content
-	chunks, err := k.chunker(data)
+	chunks, err := pipeline.Chunk(data.Content)
 	if err != nil {
 		return kvDataLinked{}, err
 	}
@@ -29,7 +23,7 @@ func (k *KV) encodeDataPipeline(data Data) (kvDataLinked, error) {
 	// compress the chunk
 	var compressedChunks [][]byte
 	for _, chunk := range chunks {
-		compressedChunk, err := compressWithZstd(chunk)
+		compressedChunk, err := pipeline.CompressWithZstd(chunk)
 		if err != nil {
 			return kvDataLinked{}, err
 		}
@@ -48,91 +42,15 @@ func (k *KV) encodeDataPipeline(data Data) (kvDataLinked, error) {
 
 	// split the chunk into reeds-solomon shards
 
-	KvDataShards, err := k.reedSolomonSplitter(data, encryptedChunks, chunkHashes)
+	shards, err := pipeline.SplitReedSolomon(encryptedChunks, chunkHashes, data.ReedSolomonShards, data.ReedSolomonParityShards)
 	if err != nil {
 		return kvDataLinked{}, err
 	}
 
 	return kvDataLinked{
 		Key:      data.Key,
-		Shards:   KvDataShards,
+		Shards:   shards,
 		Parent:   data.Parent,
 		Children: data.Children,
 	}, nil
-}
-
-func (k *KV) chunker(data Data) ([][]byte, error) {
-
-	reader := bytes.NewReader(data.Content)
-	bz := chunker.NewBuzhash(reader)
-
-	var chunks [][]byte
-
-	for chunkIndex := 0; ; chunkIndex++ {
-		buzChunk, err := bz.NextBytes()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-		chunks = append(chunks, buzChunk)
-
-	}
-	return chunks, nil
-}
-
-func compressWithZstd(data []byte) ([]byte, error) {
-	var buf bytes.Buffer
-	enc, err := zstd.NewWriter(&buf)
-	if err != nil {
-		return nil, err
-	}
-	_, err = enc.Write(data)
-	if err != nil {
-		return nil, err
-	}
-	err = enc.Close()
-	if err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
-}
-
-func (k *KV) reedSolomonSplitter(data Data, encryptedChunks []*encrypt.EncryptResult, chunkHashes []hash.Hash) ([]kvDataShard, error) {
-	enc, err := reedsolomon.New(int(data.ReedSolomonShards), int(data.ReedSolomonParityShards))
-	if err != nil {
-		return nil, fmt.Errorf("error creating reed solomon encoder: %w", err)
-	}
-
-	var KvDataShards []kvDataShard
-	for i, encryptedChunk := range encryptedChunks {
-		originalSize := uint64(len(encryptedChunk.Ciphertext))
-		shards, err := enc.Split(encryptedChunk.Ciphertext)
-		if err != nil {
-			return nil, fmt.Errorf("error splitting encrypted chunk: %w", err)
-		}
-
-		if len(shards) != int(data.ReedSolomonShards+data.ReedSolomonParityShards) {
-			return nil, fmt.Errorf("unexpected number of shards: got %d, expected %d", len(shards), data.ReedSolomonShards+data.ReedSolomonParityShards)
-		}
-
-		for j, shard := range shards {
-			KvDataShard := kvDataShard{
-				ChunkHash:               chunkHashes[i],
-				EncodedHash:             hash.HashBytes(encryptedChunk.Ciphertext), // TODO must also include metadata
-				ReedSolomonShards:       data.ReedSolomonShards,
-				ReedSolomonParityShards: data.ReedSolomonParityShards,
-				ReedSolomonIndex:        uint8(j),
-				Size:                    uint64(len(shard)),
-				OriginalSize:            originalSize,
-				EncapsulatedKey:         encryptedChunk.EncapsulatedKey,
-				Nonce:                   encryptedChunk.Nonce,
-				ChunkContent:            shard,
-			}
-			KvDataShards = append(KvDataShards, KvDataShard)
-		}
-	}
-
-	return KvDataShards, nil
 }

--- a/hash_test.go
+++ b/hash_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/i5heu/ouroboros-crypt/hash"
+	"github.com/i5heu/ouroboros-kv/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,11 +19,11 @@ func TestHashConversion(t *testing.T) {
 	fmt.Printf("Hash as %%v: %v\n", testKey)
 
 	// Try to create the prefix the same way as in storage
-	prefix1 := fmt.Sprintf("%s%x:", PARENT_PREFIX, testKey)
+	prefix1 := fmt.Sprintf("%s%x:", storage.ParentPrefix, testKey)
 	fmt.Printf("Storage prefix: %s\n", prefix1)
 
 	// Try to create the prefix the same way as in query
-	prefix2 := fmt.Sprintf("%s%x:", PARENT_PREFIX, testKey)
+	prefix2 := fmt.Sprintf("%s%x:", storage.ParentPrefix, testKey)
 	fmt.Printf("Query prefix: %s\n", prefix2)
 
 	// They should be the same

--- a/kv.go
+++ b/kv.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dgraph-io/badger/v4"
 	crypt "github.com/i5heu/ouroboros-crypt"
 	"github.com/i5heu/ouroboros-crypt/hash"
+	"github.com/i5heu/ouroboros-kv/storage"
 
 	"github.com/sirupsen/logrus"
 )
@@ -30,33 +31,11 @@ type Data struct {
 	ReedSolomonParityShards uint8       // Number of parity shards in Reed-Solomon coding (note that ReedSolomonShards + ReedSolomonParityShards is the total number of shards)
 }
 
-// KvData represents a key-value data structure with hierarchical relationships.
-type kvDataHash struct {
-	Key         hash.Hash
-	ShardHashes []hash.Hash // Hash of KvDataShards
-	Parent      hash.Hash   // Key of the parent chunk
-	Children    []hash.Hash // Keys of the child chunks
-}
-
 type kvDataLinked struct {
 	Key      hash.Hash
-	Shards   []kvDataShard // Hash of KvDataShards
-	Parent   hash.Hash     // Key of the parent chunk
-	Children []hash.Hash   // Keys of the child chunks
-}
-
-// kvDataShard represents a chunk of content that will be stored in the key-value store.
-type kvDataShard struct {
-	ChunkHash               hash.Hash // After chunking and before compression, encryption and erasure coding
-	EncodedHash             hash.Hash // After compression, encryption and erasure , including all the metadata in this struct except for EncodedHash
-	ReedSolomonShards       uint8     // Number of shards in Reed-Solomon coding (note that ReedSolomonShards + ReedSolomonParityShards is the total number of shards)
-	ReedSolomonParityShards uint8     // Number of parity shards in Reed-Solomon coding (note that ReedSolomonShards + ReedSolomonParityShards is the total number of shards)
-	ReedSolomonIndex        uint8     // Index of the chunk in the Reed-Solomon coding (note that ReedSolomonShards + ReedSolomonParityShards is the total number of shards and that ReedSolomonShards comes before ReedSolomonParityShards in the index counting)
-	Size                    uint64    // Size of the shard in bytes
-	OriginalSize            uint64    // Size of the original encrypted chunk before Reed-Solomon encoding
-	EncapsulatedKey         []byte    // ML-KEM encapsulated secret for the chunk
-	Nonce                   []byte    // AES-GCM nonce for encryption
-	ChunkContent            []byte    // Content of the chunk after compression, encryption and erasure coding
+	Shards   []storage.Shard // Hash of KvDataShards
+	Parent   hash.Hash       // Key of the parent chunk
+	Children []hash.Hash     // Keys of the child chunks
 }
 
 func Init(crypt *crypt.Crypt, config *Config) (*KV, error) {

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -1,0 +1,60 @@
+package pipeline
+
+import (
+	"bytes"
+	"io"
+
+	chunker "github.com/ipfs/boxo/chunker"
+	"github.com/klauspost/compress/zstd"
+)
+
+// Chunk breaks the provided data into Buzhash chunks.
+func Chunk(data []byte) ([][]byte, error) {
+	reader := bytes.NewReader(data)
+	bz := chunker.NewBuzhash(reader)
+
+	var chunks [][]byte
+	for {
+		chunk, err := bz.NextBytes()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		chunks = append(chunks, chunk)
+	}
+	return chunks, nil
+}
+
+// CompressWithZstd compresses data using the Zstandard algorithm.
+func CompressWithZstd(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	enc, err := zstd.NewWriter(&buf)
+	if err != nil {
+		return nil, err
+	}
+	if _, err = enc.Write(data); err != nil {
+		return nil, err
+	}
+	if err = enc.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// DecompressWithZstd decompresses Zstandard-compressed data.
+func DecompressWithZstd(data []byte) ([]byte, error) {
+	reader := bytes.NewReader(data)
+	dec, err := zstd.NewReader(reader)
+	if err != nil {
+		return nil, err
+	}
+	defer dec.Close()
+
+	var buf bytes.Buffer
+	if _, err = io.Copy(&buf, dec); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -1,0 +1,50 @@
+package pipeline
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestChunk(t *testing.T) {
+	data := bytes.Repeat([]byte("hello world"), 100)
+
+	chunks, err := Chunk(data)
+	if err != nil {
+		t.Fatalf("Chunk failed: %v", err)
+	}
+	if len(chunks) == 0 {
+		t.Fatalf("expected at least one chunk")
+	}
+
+	var combined []byte
+	for _, c := range chunks {
+		combined = append(combined, c...)
+	}
+	if !bytes.Equal(combined, data) {
+		t.Fatalf("chunked data does not reconstruct original")
+	}
+}
+
+func TestZstdCompressDecompress(t *testing.T) {
+	data := bytes.Repeat([]byte("compression test"), 50)
+
+	compressed, err := CompressWithZstd(data)
+	if err != nil {
+		t.Fatalf("CompressWithZstd failed: %v", err)
+	}
+
+	decompressed, err := DecompressWithZstd(compressed)
+	if err != nil {
+		t.Fatalf("DecompressWithZstd failed: %v", err)
+	}
+	if !bytes.Equal(decompressed, data) {
+		t.Fatalf("expected decompressed data to match original")
+	}
+}
+
+func TestDecompressWithInvalidData(t *testing.T) {
+	_, err := DecompressWithZstd([]byte("not zstd"))
+	if err == nil {
+		t.Fatalf("expected error when decompressing invalid data")
+	}
+}

--- a/pipeline/reedsolomon.go
+++ b/pipeline/reedsolomon.go
@@ -1,0 +1,86 @@
+package pipeline
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/i5heu/ouroboros-crypt/encrypt"
+	"github.com/i5heu/ouroboros-crypt/hash"
+	"github.com/i5heu/ouroboros-kv/storage"
+	"github.com/klauspost/reedsolomon"
+)
+
+func SplitReedSolomon(encryptedChunks []*encrypt.EncryptResult, chunkHashes []hash.Hash, dataShards, parityShards uint8) ([]storage.Shard, error) {
+	enc, err := reedsolomon.New(int(dataShards), int(parityShards))
+	if err != nil {
+		return nil, fmt.Errorf("error creating reed solomon encoder: %w", err)
+	}
+	var shards []storage.Shard
+	for i, encChunk := range encryptedChunks {
+		originalSize := uint64(len(encChunk.Ciphertext))
+		split, err := enc.Split(encChunk.Ciphertext)
+		if err != nil {
+			return nil, fmt.Errorf("error splitting encrypted chunk: %w", err)
+		}
+		if len(split) != int(dataShards+parityShards) {
+			return nil, fmt.Errorf("unexpected number of shards: got %d, expected %d", len(split), dataShards+parityShards)
+		}
+		for j, s := range split {
+			shards = append(shards, storage.Shard{
+				ChunkHash:               chunkHashes[i],
+				EncodedHash:             hash.HashBytes(encChunk.Ciphertext),
+				ReedSolomonShards:       dataShards,
+				ReedSolomonParityShards: parityShards,
+				ReedSolomonIndex:        uint8(j),
+				Size:                    uint64(len(s)),
+				OriginalSize:            originalSize,
+				EncapsulatedKey:         encChunk.EncapsulatedKey,
+				Nonce:                   encChunk.Nonce,
+				ChunkContent:            s,
+			})
+		}
+	}
+	return shards, nil
+}
+
+func ReconstructReedSolomon(shards []storage.Shard) (*encrypt.EncryptResult, error) {
+	if len(shards) == 0 {
+		return nil, fmt.Errorf("no shards provided for reconstruction")
+	}
+	first := shards[0]
+	dataShards := int(first.ReedSolomonShards)
+	parityShards := int(first.ReedSolomonParityShards)
+	total := dataShards + parityShards
+	if len(shards) > total {
+		return nil, fmt.Errorf("too many shards: got %d, expected at most %d", len(shards), total)
+	}
+	enc, err := reedsolomon.New(dataShards, parityShards)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Reed-Solomon decoder: %w", err)
+	}
+	rsShards := make([][]byte, total)
+	var encapsulatedKey []byte
+	var nonce []byte
+	for _, s := range shards {
+		if int(s.ReedSolomonIndex) >= total {
+			return nil, fmt.Errorf("invalid Reed-Solomon index: %d (max %d)", s.ReedSolomonIndex, total-1)
+		}
+		rsShards[s.ReedSolomonIndex] = s.ChunkContent
+		if encapsulatedKey == nil {
+			encapsulatedKey = s.EncapsulatedKey
+			nonce = s.Nonce
+		}
+	}
+	if err := enc.Reconstruct(rsShards); err != nil {
+		return nil, fmt.Errorf("failed to reconstruct Reed-Solomon shards: %w", err)
+	}
+	var reconstructed bytes.Buffer
+	if err := enc.Join(&reconstructed, rsShards, int(shards[0].OriginalSize)); err != nil {
+		return nil, fmt.Errorf("failed to join Reed-Solomon shards: %w", err)
+	}
+	return &encrypt.EncryptResult{
+		Ciphertext:      reconstructed.Bytes(),
+		EncapsulatedKey: encapsulatedKey,
+		Nonce:           nonce,
+	}, nil
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,0 +1,207 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/i5heu/ouroboros-crypt/hash"
+	pb "github.com/i5heu/ouroboros-kv/proto"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// Key prefixes for different data types in BadgerDB
+	MetadataPrefix = "meta:"
+	ChunkPrefix    = "chunk:"
+	ParentPrefix   = "parent:"
+	ChildPrefix    = "child:"
+)
+
+type Metadata struct {
+	Key         hash.Hash
+	ShardHashes []hash.Hash
+	Parent      hash.Hash
+	Children    []hash.Hash
+}
+
+type Shard struct {
+	ChunkHash               hash.Hash
+	EncodedHash             hash.Hash
+	ReedSolomonShards       uint8
+	ReedSolomonParityShards uint8
+	ReedSolomonIndex        uint8
+	Size                    uint64
+	OriginalSize            uint64
+	EncapsulatedKey         []byte
+	Nonce                   []byte
+	ChunkContent            []byte
+}
+
+type KVWriter interface {
+	Set(key, val []byte) error
+}
+
+func IsEmptyHash(h hash.Hash) bool {
+	var empty hash.Hash
+	return h == empty
+}
+
+func StoreMetadata(w KVWriter, metadata Metadata) error {
+	protoMetadata := &pb.KvDataHashProto{
+		Key:    metadata.Key[:],
+		Parent: metadata.Parent[:],
+	}
+	for _, chunkHash := range metadata.ShardHashes {
+		protoMetadata.ChunkHashes = append(protoMetadata.ChunkHashes, chunkHash[:])
+	}
+	for _, child := range metadata.Children {
+		protoMetadata.Children = append(protoMetadata.Children, child[:])
+	}
+	data, err := proto.Marshal(protoMetadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+	key := fmt.Sprintf("%s%x", MetadataPrefix, metadata.Key)
+	return w.Set([]byte(key), data)
+}
+
+func StoreShard(w KVWriter, shard Shard) error {
+	protoChunk := &pb.KvDataShardProto{
+		ChunkHash:               shard.ChunkHash[:],
+		EncodedHash:             shard.EncodedHash[:],
+		ReedSolomonShards:       uint32(shard.ReedSolomonShards),
+		ReedSolomonParityShards: uint32(shard.ReedSolomonParityShards),
+		ReedSolomonIndex:        uint32(shard.ReedSolomonIndex),
+		Size:                    shard.Size,
+		OriginalSize:            shard.OriginalSize,
+		EncapsulatedKey:         shard.EncapsulatedKey,
+		Nonce:                   shard.Nonce,
+		ChunkContent:            shard.ChunkContent,
+	}
+	data, err := proto.Marshal(protoChunk)
+	if err != nil {
+		return fmt.Errorf("failed to marshal shard: %w", err)
+	}
+	key := fmt.Sprintf("%s%x_%d", ChunkPrefix, shard.ChunkHash, shard.ReedSolomonIndex)
+	return w.Set([]byte(key), data)
+}
+
+func StoreParentChildRelationships(w KVWriter, dataKey, parent hash.Hash, children []hash.Hash) error {
+	if !IsEmptyHash(parent) {
+		parentToChildKey := fmt.Sprintf("%s%s:%s", ParentPrefix, parent, dataKey)
+		if err := w.Set([]byte(parentToChildKey), []byte{}); err != nil {
+			return fmt.Errorf("failed to store parent->child relationship: %w", err)
+		}
+		childToParentKey := fmt.Sprintf("%s%s:%s", ChildPrefix, dataKey, parent)
+		if err := w.Set([]byte(childToParentKey), []byte{}); err != nil {
+			return fmt.Errorf("failed to store child->parent relationship: %w", err)
+		}
+	}
+	for _, child := range children {
+		if IsEmptyHash(child) {
+			continue
+		}
+		parentToChildKey := fmt.Sprintf("%s%s:%s", ParentPrefix, dataKey, child)
+		if err := w.Set([]byte(parentToChildKey), []byte{}); err != nil {
+			return fmt.Errorf("failed to store parent->child relationship: %w", err)
+		}
+		childToParentKey := fmt.Sprintf("%s%s:%s", ChildPrefix, child, dataKey)
+		if err := w.Set([]byte(childToParentKey), []byte{}); err != nil {
+			return fmt.Errorf("failed to store child->parent relationship: %w", err)
+		}
+	}
+	return nil
+}
+
+func LoadMetadata(txn *badger.Txn, key hash.Hash) (Metadata, error) {
+	metadataKey := fmt.Sprintf("%s%x", MetadataPrefix, key)
+	item, err := txn.Get([]byte(metadataKey))
+	if err != nil {
+		if err == badger.ErrKeyNotFound {
+			return Metadata{}, fmt.Errorf("metadata not found for key %x", key)
+		}
+		return Metadata{}, fmt.Errorf("failed to get metadata: %w", err)
+	}
+	var protoData []byte
+	if err = item.Value(func(val []byte) error {
+		protoData = append([]byte(nil), val...)
+		return nil
+	}); err != nil {
+		return Metadata{}, fmt.Errorf("failed to read metadata value: %w", err)
+	}
+	protoMetadata := &pb.KvDataHashProto{}
+	if err = proto.Unmarshal(protoData, protoMetadata); err != nil {
+		return Metadata{}, fmt.Errorf("failed to unmarshal metadata: %w", err)
+	}
+	metadata := Metadata{Key: key}
+	if len(protoMetadata.Parent) == 64 {
+		copy(metadata.Parent[:], protoMetadata.Parent)
+	}
+	for _, chunkHashBytes := range protoMetadata.ChunkHashes {
+		if len(chunkHashBytes) == 64 {
+			var chunkHash hash.Hash
+			copy(chunkHash[:], chunkHashBytes)
+			metadata.ShardHashes = append(metadata.ShardHashes, chunkHash)
+		}
+	}
+	for _, childBytes := range protoMetadata.Children {
+		if len(childBytes) == 64 {
+			var child hash.Hash
+			copy(child[:], childBytes)
+			metadata.Children = append(metadata.Children, child)
+		}
+	}
+	return metadata, nil
+}
+
+func LoadShardsByHash(txn *badger.Txn, chunkHash hash.Hash) ([]Shard, error) {
+	var shards []Shard
+	prefix := fmt.Sprintf("%s%x_", ChunkPrefix, chunkHash)
+	it := txn.NewIterator(badger.DefaultIteratorOptions)
+	defer it.Close()
+	for it.Seek([]byte(prefix)); it.ValidForPrefix([]byte(prefix)); it.Next() {
+		item := it.Item()
+		var protoData []byte
+		if err := item.Value(func(val []byte) error {
+			protoData = append([]byte(nil), val...)
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("failed to read shard value: %w", err)
+		}
+		protoChunk := &pb.KvDataShardProto{}
+		if err := proto.Unmarshal(protoData, protoChunk); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal shard: %w", err)
+		}
+		shard := Shard{
+			ReedSolomonShards:       uint8(protoChunk.ReedSolomonShards),
+			ReedSolomonParityShards: uint8(protoChunk.ReedSolomonParityShards),
+			ReedSolomonIndex:        uint8(protoChunk.ReedSolomonIndex),
+			Size:                    protoChunk.Size,
+			OriginalSize:            protoChunk.OriginalSize,
+			EncapsulatedKey:         protoChunk.EncapsulatedKey,
+			Nonce:                   protoChunk.Nonce,
+			ChunkContent:            protoChunk.ChunkContent,
+		}
+		if len(protoChunk.ChunkHash) == 64 {
+			copy(shard.ChunkHash[:], protoChunk.ChunkHash)
+		}
+		if len(protoChunk.EncodedHash) == 64 {
+			copy(shard.EncodedHash[:], protoChunk.EncodedHash)
+		}
+		shards = append(shards, shard)
+	}
+	if len(shards) == 0 {
+		return nil, fmt.Errorf("no chunks found for hash %x", chunkHash)
+	}
+	return shards, nil
+}
+
+func DeleteMetadata(txn *badger.Txn, key hash.Hash) error {
+	metadataKey := fmt.Sprintf("%s%x", MetadataPrefix, key)
+	return txn.Delete([]byte(metadataKey))
+}
+
+func DeleteShard(txn *badger.Txn, shard Shard) error {
+	chunkKey := fmt.Sprintf("%s%x_%d", ChunkPrefix, shard.ChunkHash, shard.ReedSolomonIndex)
+	return txn.Delete([]byte(chunkKey))
+}

--- a/write.go
+++ b/write.go
@@ -6,16 +6,7 @@ import (
 
 	"github.com/dgraph-io/badger/v4"
 	"github.com/i5heu/ouroboros-crypt/hash"
-	pb "github.com/i5heu/ouroboros-kv/proto"
-	"google.golang.org/protobuf/proto"
-)
-
-const (
-	// Key prefixes for different data types in BadgerDB
-	METADATA_PREFIX = "meta:"   // For KvDataHash metadata
-	CHUNK_PREFIX    = "chunk:"  // For KvDataShard data
-	PARENT_PREFIX   = "parent:" // For parent relationships: parent_key -> child_key
-	CHILD_PREFIX    = "child:"  // For child relationships: child_key -> parent_key
+	"github.com/i5heu/ouroboros-kv/storage"
 )
 
 // WriteData encodes and stores the given Data in the key-value store
@@ -31,7 +22,7 @@ func (k *KV) WriteData(data Data) error {
 
 	// Create metadata structure with chunk hashes
 	var chunkHashes []hash.Hash
-	chunkMap := make(map[hash.Hash][]kvDataShard)
+	chunkMap := make(map[hash.Hash][]storage.Shard)
 
 	// Group chunks by their chunk hash to get unique chunk identifiers
 	for _, chunk := range encoded.Shards {
@@ -41,7 +32,7 @@ func (k *KV) WriteData(data Data) error {
 		chunkMap[chunk.ChunkHash] = append(chunkMap[chunk.ChunkHash], chunk)
 	}
 
-	metadata := kvDataHash{
+	metadata := storage.Metadata{
 		Key:         encoded.Key,
 		ShardHashes: chunkHashes,
 		Parent:      encoded.Parent,
@@ -53,13 +44,13 @@ func (k *KV) WriteData(data Data) error {
 	defer wb.Cancel()
 
 	// Store metadata
-	err = k.storeMetadataWithBatch(wb, metadata)
+	err = storage.StoreMetadata(wb, metadata)
 	if err != nil {
 		return fmt.Errorf("failed to store metadata: %w", err)
 	}
 
 	// Store parent-child relationships
-	err = k.storeParentChildRelationships(wb, metadata.Key, metadata.Parent, metadata.Children)
+	err = storage.StoreParentChildRelationships(wb, metadata.Key, metadata.Parent, metadata.Children)
 	if err != nil {
 		return fmt.Errorf("failed to store parent-child relationships: %w", err)
 	}
@@ -67,7 +58,7 @@ func (k *KV) WriteData(data Data) error {
 	// Store all chunks
 	for _, chunks := range chunkMap {
 		for _, chunk := range chunks {
-			err := k.storeChunkWithBatch(wb, chunk)
+			err := storage.StoreShard(wb, chunk)
 			if err != nil {
 				return fmt.Errorf("failed to store chunk: %w", err)
 			}
@@ -85,171 +76,6 @@ func (k *KV) WriteData(data Data) error {
 	return nil
 }
 
-// storeMetadata serializes and stores KvDataHash metadata
-func (k *KV) storeMetadata(txn *badger.Txn, metadata kvDataHash) error {
-	// Convert to protobuf
-	protoMetadata := &pb.KvDataHashProto{
-		Key:    metadata.Key[:],
-		Parent: metadata.Parent[:],
-	}
-
-	// Convert chunk hashes
-	for _, chunkHash := range metadata.ShardHashes {
-		protoMetadata.ChunkHashes = append(protoMetadata.ChunkHashes, chunkHash[:])
-	}
-
-	// Convert children hashes
-	for _, child := range metadata.Children {
-		protoMetadata.Children = append(protoMetadata.Children, child[:])
-	}
-
-	// Serialize to protobuf
-	data, err := proto.Marshal(protoMetadata)
-	if err != nil {
-		return fmt.Errorf("failed to marshal metadata: %w", err)
-	}
-
-	// Create key with metadata prefix
-	key := fmt.Sprintf("%s%x", METADATA_PREFIX, metadata.Key)
-
-	return txn.Set([]byte(key), data)
-}
-
-// storeChunk serializes and stores a KvDataShard
-func (k *KV) storeChunk(txn *badger.Txn, chunk kvDataShard) error {
-	// Convert to protobuf
-	protoChunk := &pb.KvDataShardProto{
-		ChunkHash:               chunk.ChunkHash[:],
-		EncodedHash:             chunk.EncodedHash[:],
-		ReedSolomonShards:       uint32(chunk.ReedSolomonShards),
-		ReedSolomonParityShards: uint32(chunk.ReedSolomonParityShards),
-		ReedSolomonIndex:        uint32(chunk.ReedSolomonIndex),
-		Size:                    chunk.Size,
-		OriginalSize:            chunk.OriginalSize,
-		EncapsulatedKey:         chunk.EncapsulatedKey,
-		Nonce:                   chunk.Nonce,
-		ChunkContent:            chunk.ChunkContent,
-	}
-
-	// Serialize to protobuf
-	data, err := proto.Marshal(protoChunk)
-	if err != nil {
-		return fmt.Errorf("failed to marshal chunk: %w", err)
-	}
-
-	// Create key with chunk prefix and unique identifier
-	// Use chunk hash + Reed-Solomon index to create unique keys for each shard
-	key := fmt.Sprintf("%s%x_%d", CHUNK_PREFIX, chunk.ChunkHash, chunk.ReedSolomonIndex)
-
-	return txn.Set([]byte(key), data)
-}
-
-// storeMetadataWithBatch serializes and stores KvDataHash metadata using WriteBatch
-func (k *KV) storeMetadataWithBatch(wb *badger.WriteBatch, metadata kvDataHash) error {
-	// Convert to protobuf
-	protoMetadata := &pb.KvDataHashProto{
-		Key:    metadata.Key[:],
-		Parent: metadata.Parent[:],
-	}
-
-	// Convert chunk hashes
-	for _, chunkHash := range metadata.ShardHashes {
-		protoMetadata.ChunkHashes = append(protoMetadata.ChunkHashes, chunkHash[:])
-	}
-
-	// Convert children hashes
-	for _, child := range metadata.Children {
-		protoMetadata.Children = append(protoMetadata.Children, child[:])
-	}
-
-	// Serialize to protobuf
-	data, err := proto.Marshal(protoMetadata)
-	if err != nil {
-		return fmt.Errorf("failed to marshal metadata: %w", err)
-	}
-
-	// Create key with metadata prefix
-	key := fmt.Sprintf("%s%x", METADATA_PREFIX, metadata.Key)
-
-	return wb.Set([]byte(key), data)
-}
-
-// storeChunkWithBatch serializes and stores a KvDataShard using WriteBatch
-func (k *KV) storeChunkWithBatch(wb *badger.WriteBatch, chunk kvDataShard) error {
-	// Convert to protobuf
-	protoChunk := &pb.KvDataShardProto{
-		ChunkHash:               chunk.ChunkHash[:],
-		EncodedHash:             chunk.EncodedHash[:],
-		ReedSolomonShards:       uint32(chunk.ReedSolomonShards),
-		ReedSolomonParityShards: uint32(chunk.ReedSolomonParityShards),
-		ReedSolomonIndex:        uint32(chunk.ReedSolomonIndex),
-		Size:                    chunk.Size,
-		OriginalSize:            chunk.OriginalSize,
-		EncapsulatedKey:         chunk.EncapsulatedKey,
-		Nonce:                   chunk.Nonce,
-		ChunkContent:            chunk.ChunkContent,
-	}
-
-	// Serialize to protobuf
-	data, err := proto.Marshal(protoChunk)
-	if err != nil {
-		return fmt.Errorf("failed to marshal chunk: %w", err)
-	}
-
-	// Create key with chunk prefix and unique identifier
-	// Use chunk hash + Reed-Solomon index to create unique keys for each shard
-	key := fmt.Sprintf("%s%x_%d", CHUNK_PREFIX, chunk.ChunkHash, chunk.ReedSolomonIndex)
-
-	return wb.Set([]byte(key), data)
-}
-
-// storeParentChildRelationships stores bidirectional parent-child relationships in BadgerDB
-func (k *KV) storeParentChildRelationships(wb *badger.WriteBatch, dataKey, parent hash.Hash, children []hash.Hash) error {
-	// Store parent -> child relationship (if this data has a parent)
-	if !isEmptyHash(parent) {
-		// Store: parent:PARENT_HASH -> child:DATA_KEY
-		parentToChildKey := fmt.Sprintf("%s%s:%s", PARENT_PREFIX, parent, dataKey)
-		err := wb.Set([]byte(parentToChildKey), []byte(""))
-		if err != nil {
-			return fmt.Errorf("failed to store parent->child relationship: %w", err)
-		}
-
-		// Store: child:DATA_KEY -> parent:PARENT_HASH
-		childToParentKey := fmt.Sprintf("%s%s:%s", CHILD_PREFIX, dataKey, parent)
-		err = wb.Set([]byte(childToParentKey), []byte(""))
-		if err != nil {
-			return fmt.Errorf("failed to store child->parent relationship: %w", err)
-		}
-	}
-
-	// Store child -> parent relationships (for each child this data has)
-	for _, child := range children {
-		if !isEmptyHash(child) {
-			// Store: parent:DATA_KEY -> child:CHILD_HASH
-			parentToChildKey := fmt.Sprintf("%s%s:%s", PARENT_PREFIX, dataKey, child)
-			err := wb.Set([]byte(parentToChildKey), []byte(""))
-			if err != nil {
-				return fmt.Errorf("failed to store parent->child relationship: %w", err)
-			}
-
-			// Store: child:CHILD_HASH -> parent:DATA_KEY
-			childToParentKey := fmt.Sprintf("%s%s:%s", CHILD_PREFIX, child, dataKey)
-			err = wb.Set([]byte(childToParentKey), []byte(""))
-			if err != nil {
-				return fmt.Errorf("failed to store child->parent relationship: %w", err)
-			}
-		}
-	}
-
-	return nil
-}
-
-// isEmptyHash checks if a hash is the zero value
-func isEmptyHash(h hash.Hash) bool {
-	var empty hash.Hash
-	return h == empty
-}
-
 // BatchWriteData writes multiple Data objects in a single batch operation
 func (k *KV) BatchWriteData(dataList []Data) error {
 	if len(dataList) == 0 {
@@ -260,8 +86,8 @@ func (k *KV) BatchWriteData(dataList []Data) error {
 
 	// Process all data through encoding pipeline first
 	var encodedData []kvDataLinked
-	var allMetadata []kvDataHash
-	var allChunks []kvDataShard
+	var allMetadata []storage.Metadata
+	var allChunks []storage.Shard
 
 	for _, data := range dataList {
 		encoded, err := k.encodeDataPipeline(data)
@@ -282,7 +108,7 @@ func (k *KV) BatchWriteData(dataList []Data) error {
 			allChunks = append(allChunks, chunk)
 		}
 
-		metadata := kvDataHash{
+		metadata := storage.Metadata{
 			Key:         encoded.Key,
 			ShardHashes: chunkHashes,
 			Parent:      encoded.Parent,
@@ -295,13 +121,13 @@ func (k *KV) BatchWriteData(dataList []Data) error {
 	err := k.badgerDB.Update(func(txn *badger.Txn) error {
 		// Store all metadata
 		for _, metadata := range allMetadata {
-			err := k.storeMetadata(txn, metadata)
+			err := storage.StoreMetadata(txn, metadata)
 			if err != nil {
 				return fmt.Errorf("failed to store metadata for key %x: %w", metadata.Key, err)
 			}
 
 			// Store parent-child relationships
-			err = k.storeParentChildRelationshipsTxn(txn, metadata.Key, metadata.Parent, metadata.Children)
+			err = storage.StoreParentChildRelationships(txn, metadata.Key, metadata.Parent, metadata.Children)
 			if err != nil {
 				return fmt.Errorf("failed to store parent-child relationships for key %x: %w", metadata.Key, err)
 			}
@@ -309,7 +135,7 @@ func (k *KV) BatchWriteData(dataList []Data) error {
 
 		// Store all chunks
 		for _, chunk := range allChunks {
-			err := k.storeChunk(txn, chunk)
+			err := storage.StoreShard(txn, chunk)
 			if err != nil {
 				return fmt.Errorf("failed to store chunk %x: %w", chunk.ChunkHash, err)
 			}
@@ -324,46 +150,5 @@ func (k *KV) BatchWriteData(dataList []Data) error {
 	}
 
 	log.Debugf("Successfully batch wrote %d data objects", len(dataList))
-	return nil
-}
-
-// storeParentChildRelationshipsTxn stores parent-child relationships using a transaction
-func (k *KV) storeParentChildRelationshipsTxn(txn *badger.Txn, dataKey, parent hash.Hash, children []hash.Hash) error {
-	// Store parent -> child relationship (if this data has a parent)
-	if !isEmptyHash(parent) {
-		// Store: parent:PARENT_HASH -> child:DATA_KEY
-		parentToChildKey := fmt.Sprintf("%s%s:%s", PARENT_PREFIX, parent, dataKey)
-		err := txn.Set([]byte(parentToChildKey), []byte{})
-		if err != nil {
-			return fmt.Errorf("failed to store parent->child relationship: %w", err)
-		}
-
-		// Store: child:DATA_KEY -> parent:PARENT_HASH
-		childToParentKey := fmt.Sprintf("%s%s:%s", CHILD_PREFIX, dataKey, parent)
-		err = txn.Set([]byte(childToParentKey), []byte{})
-		if err != nil {
-			return fmt.Errorf("failed to store child->parent relationship: %w", err)
-		}
-	}
-
-	// Store child -> parent relationships (for each child this data has)
-	for _, child := range children {
-		if !isEmptyHash(child) {
-			// Store: parent:DATA_KEY -> child:CHILD_HASH
-			parentToChildKey := fmt.Sprintf("%s%s:%s", PARENT_PREFIX, dataKey, child)
-			err := txn.Set([]byte(parentToChildKey), []byte{})
-			if err != nil {
-				return fmt.Errorf("failed to store parent->child relationship: %w", err)
-			}
-
-			// Store: child:CHILD_HASH -> parent:DATA_KEY
-			childToParentKey := fmt.Sprintf("%s%s:%s", CHILD_PREFIX, child, dataKey)
-			err = txn.Set([]byte(childToParentKey), []byte{})
-			if err != nil {
-				return fmt.Errorf("failed to store child->parent relationship: %w", err)
-			}
-		}
-	}
-
 	return nil
 }


### PR DESCRIPTION
## Summary
- extract metadata and shard persistence into new `storage` package
- move Reed-Solomon split/reconstruct logic into `pipeline` for reuse
- update pipelines and readers to use shared storage helpers

## Testing
- `go test ./...` *(fails: signal interrupt after extensive debug output)*

------
https://chatgpt.com/codex/tasks/task_e_6895d233da888330bea954959fecee67