### PR TITLE
Add alias tracking for duplicate writes

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -1,0 +1,70 @@
+package ouroboroskv
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/i5heu/ouroboros-crypt/hash"
+)
+
+const ALIAS_PREFIX = "alias:"
+
+type aliasMapping struct {
+	Alias     hash.Hash
+	Canonical hash.Hash
+}
+
+func aliasKeyBytes(key hash.Hash) []byte {
+	return []byte(fmt.Sprintf("%s%x", ALIAS_PREFIX, key))
+}
+
+func generateAliasKey(canonical hash.Hash, aliasIndex uint64) hash.Hash {
+	if aliasIndex == 0 {
+		return canonical
+	}
+
+	suffix := make([]byte, len(canonical)+8)
+	copy(suffix, canonical[:])
+	binary.BigEndian.PutUint64(suffix[len(canonical):], aliasIndex)
+
+	return hash.HashBytes(suffix)
+}
+
+func (k *KV) storeAliasWithBatch(wb *badger.WriteBatch, alias, canonical hash.Hash) error {
+	value := make([]byte, len(canonical))
+	copy(value, canonical[:])
+	return wb.Set(aliasKeyBytes(alias), value)
+}
+
+func (k *KV) storeAliasTxn(txn *badger.Txn, alias, canonical hash.Hash) error {
+	value := make([]byte, len(canonical))
+	copy(value, canonical[:])
+	return txn.Set(aliasKeyBytes(alias), value)
+}
+
+func (k *KV) deleteAliasTxn(txn *badger.Txn, alias hash.Hash) error {
+	return txn.Delete(aliasKeyBytes(alias))
+}
+
+func (k *KV) resolveAliasTxn(txn *badger.Txn, key hash.Hash) (hash.Hash, bool, error) {
+	item, err := txn.Get(aliasKeyBytes(key))
+	if err != nil {
+		if err == badger.ErrKeyNotFound {
+			return hash.Hash{}, false, nil
+		}
+		return hash.Hash{}, false, err
+	}
+
+	var value []byte
+	if err := item.Value(func(val []byte) error {
+		value = append([]byte(nil), val...)
+		return nil
+	}); err != nil {
+		return hash.Hash{}, false, err
+	}
+
+	var canonical hash.Hash
+	copy(canonical[:], value)
+	return canonical, true, nil
+}

--- a/refcount.go
+++ b/refcount.go
@@ -1,0 +1,96 @@
+package ouroboroskv
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/i5heu/ouroboros-crypt/hash"
+)
+
+const REFCOUNT_PREFIX = "refcount:"
+
+func refCountKeyBytes(key hash.Hash) []byte {
+	return []byte(fmt.Sprintf("%s%x", REFCOUNT_PREFIX, key))
+}
+
+func encodeRefCount(count uint64) []byte {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, count)
+	return buf
+}
+
+func decodeRefCount(data []byte) uint64 {
+	if len(data) >= 8 {
+		return binary.BigEndian.Uint64(data[:8])
+	}
+
+	var buf [8]byte
+	copy(buf[8-len(data):], data)
+	return binary.BigEndian.Uint64(buf[:])
+}
+
+func (k *KV) getRefCountTxn(txn *badger.Txn, key hash.Hash) (uint64, error) {
+	item, err := txn.Get(refCountKeyBytes(key))
+	if err != nil {
+		if err == badger.ErrKeyNotFound {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	var value []byte
+	if err := item.Value(func(val []byte) error {
+		value = append([]byte(nil), val...)
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+
+	if len(value) == 0 {
+		return 0, nil
+	}
+
+	return decodeRefCount(value), nil
+}
+
+func (k *KV) getRefCount(key hash.Hash) (uint64, error) {
+	var count uint64
+	err := k.badgerDB.View(func(txn *badger.Txn) error {
+		var err error
+		count, err = k.getRefCountTxn(txn, key)
+		return err
+	})
+
+	return count, err
+}
+
+func (k *KV) getRefCounts(keys []hash.Hash) (map[hash.Hash]uint64, error) {
+	unique := make(map[hash.Hash]struct{})
+	for _, key := range keys {
+		unique[key] = struct{}{}
+	}
+
+	counts := make(map[hash.Hash]uint64, len(unique))
+	err := k.badgerDB.View(func(txn *badger.Txn) error {
+		for key := range unique {
+			count, err := k.getRefCountTxn(txn, key)
+			if err != nil {
+				return err
+			}
+			counts[key] = count
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for key := range unique {
+		if _, ok := counts[key]; !ok {
+			counts[key] = 0
+		}
+	}
+
+	return counts, nil
+}


### PR DESCRIPTION
## Summary
- track reference counts separately from metadata and persist alias keys for each write
- update write, read, and delete flows to manage alias mappings and resolve canonical keys
- ensure DataExists and batch operations respect alias references so duplicate writes survive deletions

## Testing
- go test -run TestDuplicateWriteDelete -v
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ee6725c59c8330ae1cc44f91e960d3